### PR TITLE
window-jumper: fix for classes with other characters than a-Z

### DIFF
--- a/tools/dmenu-i3-window-jumper
+++ b/tools/dmenu-i3-window-jumper
@@ -30,7 +30,7 @@ _die() {
 
 _i3_get_app_tree() {
     i3-msg -t get_tree | \
-        egrep -o "(class.:.[a-Z]+.|title.:.[()0123456789~. -/a-Z]+)" | \
+        egrep -o "(class\":\".[^\"]+\"|title\":\"[^\"]+)" | \
         sed 's/"//g;s/class://g;s/title://g' | \
         while read -r line; read -r line2; do  \
             printf "%s\\n" "═ ${line} :: ${line2}"; \


### PR DESCRIPTION
I had an issue jumping to my terminals while other windows worked fine.
Reason: The class "gnome-terminal" contains a "-" which was not accepted by the regular expression. Fixed it to accept everything except "end of string". Also replaced the lazy "." by an actual match to \".